### PR TITLE
Add New Stylus Dependencies

### DIFF
--- a/www/package.json
+++ b/www/package.json
@@ -26,11 +26,13 @@
     "gulp-util": "^3.0.3",
     "gulp-watch": "^4.1.1",
     "jade": "^1.9.2",
+    "jeet": "^6.1.2",
     "jshint-stylish": "^1.0.0",
     "lodash": "^3.2.0",
     "nib": "^1.1.0",
     "require-directory": "^2.0.0",
     "rimraf": "^2.2.8",
+    "rupture": "^0.6.1",
     "stylus": "^0.50.0",
     "vinyl-buffer": "^1.0.0",
     "vinyl-source-stream": "^1.0.0"

--- a/www/src/assets/css/main.styl
+++ b/www/src/assets/css/main.styl
@@ -3,9 +3,14 @@
 	Assigned:      Oliver Benns (@oliverbenns)
 	Date:          January 2015
 	Notes:         Using the BEM naming convention (https://bem.info/method/)
-	Dependencies:  Nib (https://github.com/tj/nib)
+	Dependencies:  Nib (https://github.com/tj/nib),
+	               Jeet (https://github.com/mojotech/jeet),
+	               Rupture (https://github.com/jenius/rupture)
 	========================================================================== */
 
+// Third Party
+@import "jeet"
+@import "rupture"
 @import "nib"
 
 // Config

--- a/www/tasks/stylus.js
+++ b/www/tasks/stylus.js
@@ -5,6 +5,10 @@ var rename = require('gulp-rename');
 var stylus = require('gulp-stylus');
 var watch = require('gulp-watch');
 
+var nib = require('nib');
+var rupture = require('rupture');
+var jeet = require('jeet');
+
 var minifiedFilename = (require('./helpers/get-minified-filename')()) + '.css';
 
 gulp.task('stylus', function () {
@@ -12,7 +16,9 @@ gulp.task('stylus', function () {
 		compress: true,
 		errors: true,
 		use: [
-			(require('nib')())
+			jeet(),
+			rupture(),
+			nib()
 		]
 	};
 


### PR DESCRIPTION
I've been doing a good amount of research of extra tools that can make our styles more efficient and make our workflow as rapid as possible. I've been sandboxing these tools and it's clear they will be adding a lot of value.

This includes:
- **[Jeet](https://github.com/mojotech/jeet)** - A good responsive grid toolkit that's pretty advanced and should make our lives a lot easier. I've also started contributing to this project and hope to continue doing so. The guys behind this project seem pretty solid and the support is good.
- **[Rupture](https://github.com/jenius/rupture)** - Shorthand media queries

At this stage I am also considering using [css autoprefixer](https://github.com/postcss/autoprefixer) over [Nib](https://github.com/tj/nib) as it seems more extensive, uses data from [caniuse.com](http://www.caniuse.com), far more popular and allows you to define browser you wish to support. It seems there is a [stylus port](https://www.npmjs.com/package/autoprefixer-stylus) but I can't seem to get this working with our Gulp flow at the minute.
