### PR TITLE
Add config file to jade locals

### DIFF
--- a/www/.config.json
+++ b/www/.config.json
@@ -1,3 +1,4 @@
 {
-	"EXAMPLE": "[example]"
+	"EXAMPLE": "[example]",
+	"host": "http://localhost:3000"
 }

--- a/www/src/views/_includes/header.jade
+++ b/www/src/views/_includes/header.jade
@@ -1,2 +1,3 @@
 h1 Header
+p Welcome to #{cfg.host}
 p This is _includes/header.jade

--- a/www/tasks/jade.js
+++ b/www/tasks/jade.js
@@ -55,8 +55,12 @@ var locals = {
 	pkg: _.pick(require('../package.json'), [
 		'name',
 		'version'
-	])
-	// @TODO: Add config file here.
+	]),
+
+	// Add contents of the config.json as cfg
+	// NOTE: 'cfg' is used instead of 'config' so not to be confused with
+	// our Angular config.js service.
+	cfg: require('../.config.json')
 };
 
 gulp.task('jade:pages', function() {

--- a/www/tasks/jade.js
+++ b/www/tasks/jade.js
@@ -58,8 +58,8 @@ var locals = {
 	]),
 
 	// Add contents of the config.json as cfg
-	// NOTE: 'cfg' is used instead of 'config' so not to be confused with
-	// our Angular config.js service.
+	// NOTE: 'cfg' is used instead of 'config' so it doesn't get confused with
+	// a frontend service/module (e.g. the Angular config.js service).
 	cfg: require('../.config.json')
 };
 


### PR DESCRIPTION
This PR adds a config file to jade locals which can be used within jade templates (as per the example in the header.jade file).

To render a config variable simply use `#{cfg.someVariable}` within the Jade template.

Addresses #3 
