### PR TITLE
Various Enhancements

### DIFF
--- a/www/.jscsrc
+++ b/www/.jscsrc
@@ -57,5 +57,6 @@
 	"requireCapitalizedConstructors": true,
 	"requireDotNotation": true,
 	"disallowYodaConditions": true,
-	"disallowNewlineBeforeBlockStatements": true
+	"disallowNewlineBeforeBlockStatements": true,
+	"esnext": true
 }

--- a/www/.jshintrc
+++ b/www/.jshintrc
@@ -20,7 +20,7 @@
 	"debug": false, // Allow debugger statements e.g. browser breakpoints.
 	"eqnull": false, // Tolerate use of `== null`.
 	"es5": false, // Allow EcmaScript 5 syntax.
-	"esnext": false, // Allow ES.next specific features such as `const` and `let`.
+	"esnext": true, // Allow ES.next specific features such as `const` and `let`.
 	"evil": false, // Tolerate use of `eval`.
 	"expr": true, // Tolerate `ExpressionStatement` as Programs.
 	"funcscope": false, // Tolerate declarations of variables inside of control structures while accessing them later from the outside.

--- a/www/package.json
+++ b/www/package.json
@@ -5,7 +5,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "build": "gulp",
+    "release": "gulp release"
   },
   "author": "Inlight Media",
   "dependencies": {

--- a/www/package.json
+++ b/www/package.json
@@ -10,9 +10,11 @@
   },
   "author": "Inlight Media",
   "dependencies": {
+    "babelify": "^6.1.3",
     "browserify": "^8.1.3",
     "gulp": "^3.8.11",
     "gulp-filter": "^2.0.1",
+    "gulp-if": "~1.2.5",
     "gulp-imagemin": "^2.2.0",
     "gulp-jade": "^0.11.0",
     "gulp-jscs": "^1.4.0",
@@ -38,8 +40,7 @@
     "rupture": "^0.6.1",
     "stylus": "^0.50.0",
     "vinyl-buffer": "^1.0.0",
-    "vinyl-source-stream": "^1.0.0",
-    "gulp-if": "~1.2.5"
+    "vinyl-source-stream": "^1.0.0"
   },
   "devDependencies": {
     "gulp-connect": "^2.2.0"

--- a/www/readme.md
+++ b/www/readme.md
@@ -9,7 +9,13 @@ Steps for running the www development environment:
 ```
 cd www
 npm install
-gulp
+npm run build
+```
+
+For a release build:
+
+```
+npm run release
 ```
 
 The website should now be accessible at ```http://localhost:3000```.

--- a/www/src/assets/js/example/fn.js
+++ b/www/src/assets/js/example/fn.js
@@ -1,3 +1,3 @@
-module.exports = function() {
+export default function() {
 	return 'hello world';
-};
+}

--- a/www/src/assets/js/example/obj.js
+++ b/www/src/assets/js/example/obj.js
@@ -1,3 +1,3 @@
-module.exports = {
+export default {
 	foo: 'bar'
 };

--- a/www/src/assets/js/main.js
+++ b/www/src/assets/js/main.js
@@ -1,5 +1,5 @@
-var obj = require('./example/obj');
-var fn = require('./example/fn');
+import obj from './example/obj';
+import fn from './example/fn';
 
 console.log('obj', obj);
 var result = fn();

--- a/www/tasks/jade.js
+++ b/www/tasks/jade.js
@@ -50,6 +50,12 @@ var templates = 'src/views/_templates/**/*.jade';
  * Jade locals.
  * @type {Object}
  */
+
+// For handling different environment variables.
+// Get config depending on node environment.
+var environment = process.env.NODE_ENV || '';
+var config = require('../.config' + (environment.length ? '.' + environment : '') + '.json');
+
 var locals = {
 	// Add *some* contents of the package.json as pkg.
 	pkg: _.pick(require('../package.json'), [
@@ -60,7 +66,7 @@ var locals = {
 	// Add contents of the config.json as cfg
 	// NOTE: 'cfg' is used instead of 'config' so it doesn't get confused with
 	// a frontend service/module (e.g. the Angular config.js service).
-	cfg: require('../.config.json')
+	cfg: config
 };
 
 gulp.task('jade:pages', function() {

--- a/www/tasks/javascript.js
+++ b/www/tasks/javascript.js
@@ -31,7 +31,7 @@ function runTask(release) {
 		}))
 		// Add transformation tasks to the pipeline here.
 		.pipe(gulpif(release, uglify()))
-		.pipe(sourcemaps.write('./')) // TODO: Do we need sourcemaps during release?
+		.pipe(sourcemaps.write('./'))
 		.pipe(gulp.dest('dist/assets/js'));
 }
 

--- a/www/tasks/javascript.js
+++ b/www/tasks/javascript.js
@@ -10,6 +10,7 @@ var sourcemaps = require('gulp-sourcemaps');
 var uglify = require('gulp-uglify');
 var watch = require('gulp-watch');
 var gulpif = require('gulp-if');
+var babelify = require('babelify');
 
 var minifiedFilename = (require('./helpers/get-minified-filename')()) + '.js';
 
@@ -19,7 +20,7 @@ function runTask(release) {
 			path.join(__dirname, '../src/assets/js/main.js')
 		],
 		debug: true
-	});
+	}).transform(babelify);
 
 	return bundler
 		.bundle()

--- a/www/tasks/javascript.js
+++ b/www/tasks/javascript.js
@@ -31,7 +31,7 @@ function runTask(release) {
 		}))
 		// Add transformation tasks to the pipeline here.
 		.pipe(gulpif(release, uglify()))
-		.pipe(gulpif(release, sourcemaps.write('./'))) // TODO: Do we need sourcemaps during release?
+		.pipe(sourcemaps.write('./')) // TODO: Do we need sourcemaps during release?
 		.pipe(gulp.dest('dist/assets/js'));
 }
 


### PR DESCRIPTION
- Added npm run tasks to fix #24. You can now run `npm run build` and `npm run release`.
- Added babel transpiler to allow us to start using es6.
- Convert current js to es6
- Fix #21 
- Allow sourcemapping on any gulp task
